### PR TITLE
Add cargo metadata.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2021"
 description = "A tool to convert markdown into reveal.js slides"
 authors = ["Jonathan Pallant <jonathan.pallant@ferrous-systems.com>"]
 license = "Apache-2.0 OR MIT"
+keywords = ["markdown", "slides"]
+categories = ["command-line-utilities", "template-engine"]
+repository = "https://github.com/ferrous-systems/mdslides/"
+exclude = [".github"]
+readme = "README.md"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
The "repository" key in particular is required for cargo-binstall to work.