### PR TITLE
Reformat CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,19 @@
 # Change Log
 
-## [v0.3.0](https://github.com/ferrous-systems/mdslides/releases/tag/v0.3.0) - 2023-05-23
+## v0.3.0 (2023-05-23, [Github Release](https://github.com/ferrous-systems/mdslides/releases/tag/v0.3.0))
 
 * The `index.html` file now includes headings and subheadings
 * Split into `main.rs` and `lib.rs` and added unit tests.
 
-## [v0.2.0](https://github.com/ferrous-systems/mdslides/releases/tag/v0.2.0) - 2023-04-23
+## v0.2.0 (2023-04-23, [Github Release](https://github.com/ferrous-systems/mdslides/releases/tag/v0.2.0))
 
 * Added extra license info to `--help`
 * Generates `index.html` file
 
-## [v0.1.1](https://github.com/ferrous-systems/mdslides/releases/tag/v0.1.1) - 2023-04-21
+## v0.1.1 (2023-04-21, [Github Release](https://github.com/ferrous-systems/mdslides/releases/tag/v0.1.1))
 
 * Added metadata to `Cargo.toml`
 
-## [v0.1.0](https://github.com/ferrous-systems/mdslides/releases/tag/v0.1.0) - 2023-04-21
+## v0.1.0 (2023-04-21, [Github Release](https://github.com/ferrous-systems/mdslides/releases/tag/v0.1.0))
 
 * First version


### PR DESCRIPTION
Now parse-changelog can read it correctly, which means our Github Releases will have the correct details in them.