### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.5.0 (2024-11-21, [Github Release](https://github.com/ferrous-systems/mdslides/releases/tag/v0.5.0))
+
+* Converts `dot` code blocks into SVG using Graphviz
+* Upgrade cargo-dist
+* Added some test cases
+
 ## v0.4.0 (2023-05-23, [Github Release](https://github.com/ferrous-systems/mdslides/releases/tag/v0.4.0))
 
 * Supports 'empty' links in the SUMMARY.md page

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "mdslides"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 OR MIT"
 name = "mdslides"
 readme = "README.md"
 repository = "https://github.com/ferrous-systems/mdslides/"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 clap = {version = "4", features = ["derive"]}


### PR DESCRIPTION
Updated the package version to 0.5.0 and updates the CHANGELOG.

The release will be handled by `cargo-dist` when we push a `v0.5.0` tag.