### PR TITLE
Bump to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Change Log
 
+## v0.6.1 (2025-02-04, [Github Release](https://github.com/ferrous-systems/mdslides/releases/tag/v0.6.1))
+
+* Drops Arm Windows build due to build failures.
+
 ## v0.6.0 (2025-02-04, [Github Release](https://github.com/ferrous-systems/mdslides/releases/tag/v0.6.0))
 
 * Adds `skip_slides` functionality
 * Upgrade cargo-dist to v0.28
+* Adds Arm Windows builds
 
 ## v0.5.0 (2024-11-21, [Github Release](https://github.com/ferrous-systems/mdslides/releases/tag/v0.5.0))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "mdslides"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 OR MIT"
 name = "mdslides"
 readme = "README.md"
 repository = "https://github.com/ferrous-systems/mdslides/"
-version = "0.6.0"
+version = "0.6.1"
 
 [dependencies]
 clap = {version = "4", features = ["derive"]}


### PR DESCRIPTION
The release of 0.6.0 broke (https://github.com/ferrous-systems/mdslides/actions/runs/13138063283/job/36658161264) so let's try again without Windows on Arm.